### PR TITLE
Show energy meter devices as a power meter in the Energy tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -1169,7 +1169,7 @@ const CapabilityMap2 = {
     {
         class: "sensor",
         exclude: "",
-        capabilities: [ 'measure_power' ],
+        capabilities: [ 'meter_power' ],
         icon: "energy.svg",
         iconPriority: 1
     },
@@ -1177,7 +1177,7 @@ const CapabilityMap2 = {
     {
         class: "sensor",
         exclude: "",
-        capabilities: [ 'meter_power' ],
+        capabilities: [ 'measure_power' ],
         icon: "energy.svg",
         iconPriority: 1
     },

--- a/app.js
+++ b/app.js
@@ -2631,6 +2631,10 @@ class MyApp extends OAuth2App
 
                         // Find supported capabilities
                         var deviceCapabilities = component.capabilities;
+
+                        // A device that measures power / energy but has no switch is a meter, so show it in the Energy tab as a (cumulative) power meter
+                        const hasSTCapability = ( id ) => deviceCapabilities.findIndex( ( element ) => element.id === id ) >= 0;
+                        const isPowerMeterDevice = ( hasSTCapability( 'energyMeter' ) || hasSTCapability( 'powerMeter' ) ) && !hasSTCapability( 'switch' );
                         for ( const deviceCapability of deviceCapabilities )
                         {
 							if (deviceCapability.id === 'custom.disabledComponents')
@@ -2705,15 +2709,21 @@ class MyApp extends OAuth2App
                         {
                             // Add this device to the table
                             this.updateLog( `Adding device ${device.label} with ${this.varToString( capabilities )}` );
-                            devices.push(
-                            {
+                            const deviceEntry = {
                                 "name": device.label + ": " + component.id,
                                 "icon": iconName, // relative to: /drivers/<driver_id>/assets/
                                 "class": className,
                                 "capabilities": capabilities,
-								settings,
+                                "settings": { ...settings, energyCumulative: isPowerMeterDevice },
                                 data
-                            } );
+                            };
+
+                            if ( isPowerMeterDevice )
+                            {
+                                deviceEntry.energy = { "cumulative": true };
+                            }
+
+                            devices.push( deviceEntry );
                         }
                     }
                 }

--- a/app.js
+++ b/app.js
@@ -2709,18 +2709,22 @@ class MyApp extends OAuth2App
                         {
                             // Add this device to the table
                             this.updateLog( `Adding device ${device.label} with ${this.varToString( capabilities )}` );
+                            const isCumulativeMeter = isPowerMeterDevice && capabilities.includes( 'meter_power' );
                             const deviceEntry = {
                                 "name": device.label + ": " + component.id,
                                 "icon": iconName, // relative to: /drivers/<driver_id>/assets/
                                 "class": className,
                                 "capabilities": capabilities,
-                                "settings": { ...settings, energyCumulative: isPowerMeterDevice },
+                                "settings": { ...settings, energyCumulative: isCumulativeMeter },
                                 data
                             };
 
-                            if ( isPowerMeterDevice )
+                            if ( isCumulativeMeter )
                             {
-                                deviceEntry.energy = { "cumulative": true };
+                                deviceEntry.energy = {
+                                    "cumulative": true,
+                                    "cumulativeImportedCapability": "meter_power"
+                                };
                             }
 
                             devices.push( deviceEntry );

--- a/app.json
+++ b/app.json
@@ -2431,6 +2431,28 @@
         {
           "type": "group",
           "label": {
+            "en": "Energy",
+            "ko": "에너지"
+          },
+          "children": [
+            {
+              "id": "energyCumulative",
+              "type": "checkbox",
+              "label": {
+                "en": "Show as home power meter in the Energy tab",
+                "ko": "Energy 탭에 전력계로 표시"
+              },
+              "value": false,
+              "hint": {
+                "en": "Treat this device as a cumulative meter that measures the whole home, so it is shown as the power meter in the Energy tab.",
+                "ko": "이 기기를 집 전체 사용량을 측정하는 누적 미터로 취급하여 Energy 탭에 전력계로 표시합니다."
+              }
+            }
+          ]
+        },
+        {
+          "type": "group",
+          "label": {
             "en": "Date",
             "nl": "RGBW-lamp"
           },

--- a/drivers/stDevice/device.js
+++ b/drivers/stDevice/device.js
@@ -73,6 +73,38 @@ class STDevice extends Homey.Device
             this.setClass('lock');
         }
 
+        // Migrate energy meter devices so they show up in the Energy tab as a power meter
+        if ( this.hasCapability( 'meter_power' ) || this.hasCapability( 'measure_power' ) )
+        {
+            if ( hasApiAccessAtInit && !this.hasCapability( 'measure_power' ) )
+            {
+                try
+                {
+                    // Only add live power if the ST device can actually report it
+                    const stValue = await this.homey.app.getDeviceCapabilityValue( devData.id, component, 'powerMeter' );
+                    if ( stValue && stValue.power )
+                    {
+                        await this.addCapability( 'measure_power' );
+                    }
+                }
+                catch ( err )
+                {
+                    this.homey.app.updateLog( `${this.getName()} has no powerMeter capability so live power is not available` );
+                }
+            }
+
+            // One-time migration: default the Energy tab power meter setting for devices paired before the setting existed.
+            // A pure meter device (no switch) measures the home consumption, so treat it as a cumulative meter by default.
+            if ( this.getStoreValue( 'energyCumulativeMigrated' ) === null )
+            {
+                const isPureMeter = ( this.getClass() === 'sensor' ) && !this.hasCapability( 'onoff' );
+                await this.setSettings( { energyCumulative: isPureMeter } ).catch( this.error );
+                await this.setStoreValue( 'energyCumulativeMigrated', true ).catch( this.error );
+            }
+
+            await this.updateEnergyCumulative();
+        }
+
         if (this.hasCapability('tag_button_status') && !this.hasCapability('tag_button_timestamp'))
         {
             this.addCapability('tag_button_timestamp');
@@ -534,6 +566,29 @@ class STDevice extends Homey.Device
             {
                 this.setCapabilityValue('image_capture', this.convertDate(this.captureTime, newSettings)).catch(this.error);
             }
+        }
+
+        if (changedKeys.indexOf("energyCumulative") >= 0)
+        {
+            await this.setEnergy( newSettings.energyCumulative === true ? { cumulative: true } : {} ).catch( this.error );
+        }
+    }
+
+    async updateEnergyCumulative()
+    {
+        try
+        {
+            const cumulative = this.getSetting( 'energyCumulative' ) === true;
+            const energy = this.getEnergy();
+            const currentlyCumulative = ( energy && energy.cumulative === true );
+            if ( currentlyCumulative !== cumulative )
+            {
+                await this.setEnergy( cumulative ? { cumulative: true } : {} );
+            }
+        }
+        catch ( err )
+        {
+            this.error( err );
         }
     }
 

--- a/drivers/stDevice/device.js
+++ b/drivers/stDevice/device.js
@@ -73,32 +73,27 @@ class STDevice extends Homey.Device
             this.setClass('lock');
         }
 
-        // Migrate energy meter devices so they show up in the Energy tab as a power meter
+        // Keep power capabilities in sync for devices paired before the mapping was corrected.
         if ( this.hasCapability( 'meter_power' ) || this.hasCapability( 'measure_power' ) )
         {
-            if ( hasApiAccessAtInit && !this.hasCapability( 'measure_power' ) )
+            if ( hasApiAccessAtInit )
             {
-                try
+                if ( !this.hasCapability( 'meter_power' ) && await this.stReportsCumulativeEnergy( devData.id, component ) )
                 {
-                    // Only add live power if the ST device can actually report it
-                    const stValue = await this.homey.app.getDeviceCapabilityValue( devData.id, component, 'powerMeter' );
-                    if ( stValue && stValue.power )
-                    {
-                        await this.addCapability( 'measure_power' );
-                    }
+                    await this.addCapability( 'meter_power' ).catch( this.error );
                 }
-                catch ( err )
+
+                if ( !this.hasCapability( 'measure_power' ) && await this.stReportsLivePower( devData.id, component ) )
                 {
-                    this.homey.app.updateLog( `${this.getName()} has no powerMeter capability so live power is not available` );
+                    await this.addCapability( 'measure_power' ).catch( this.error );
                 }
             }
 
             // One-time migration: default the Energy tab power meter setting for devices paired before the setting existed.
-            // A pure meter device (no switch) measures the home consumption, so treat it as a cumulative meter by default.
             if ( this.getStoreValue( 'energyCumulativeMigrated' ) === null )
             {
-                const isPureMeter = ( this.getClass() === 'sensor' ) && !this.hasCapability( 'onoff' );
-                await this.setSettings( { energyCumulative: isPureMeter } ).catch( this.error );
+                const isCumulativeMeter = ( this.getClass() === 'sensor' ) && !this.hasCapability( 'onoff' ) && this.hasCapability( 'meter_power' );
+                await this.setSettings( { energyCumulative: isCumulativeMeter } ).catch( this.error );
                 await this.setStoreValue( 'energyCumulativeMigrated', true ).catch( this.error );
             }
 
@@ -570,25 +565,79 @@ class STDevice extends Homey.Device
 
         if (changedKeys.indexOf("energyCumulative") >= 0)
         {
-            await this.setEnergy( newSettings.energyCumulative === true ? { cumulative: true } : {} ).catch( this.error );
+            const cumulative = ( newSettings.energyCumulative === true ) && this.hasCapability( 'meter_power' );
+            await this.setEnergy( cumulative ? this.getCumulativeEnergyConfiguration() : {} ).catch( this.error );
         }
+    }
+
+    getCumulativeEnergyConfiguration()
+    {
+        return {
+            cumulative: true,
+            cumulativeImportedCapability: 'meter_power'
+        };
     }
 
     async updateEnergyCumulative()
     {
         try
         {
-            const cumulative = this.getSetting( 'energyCumulative' ) === true;
+            const cumulative = ( this.getSetting( 'energyCumulative' ) === true ) && this.hasCapability( 'meter_power' );
             const energy = this.getEnergy();
             const currentlyCumulative = ( energy && energy.cumulative === true );
-            if ( currentlyCumulative !== cumulative )
+            const cumulativeCapability = energy && energy.cumulativeImportedCapability;
+            if ( currentlyCumulative !== cumulative || ( cumulative && cumulativeCapability !== 'meter_power' ) )
             {
-                await this.setEnergy( cumulative ? { cumulative: true } : {} );
+                await this.setEnergy( cumulative ? this.getCumulativeEnergyConfiguration() : {} );
             }
         }
         catch ( err )
         {
             this.error( err );
+        }
+    }
+
+    async stReportsLivePower( deviceId, component )
+    {
+        try
+        {
+            const stValue = await this.homey.app.getDeviceCapabilityValue( deviceId, component, 'powerMeter' );
+            const power = _.get( stValue, 'power.value' );
+            return ( power !== undefined && power !== null );
+        }
+        catch ( err )
+        {
+            this.homey.app.updateLog( `${this.getName()} has no powerMeter capability so live power is not available` );
+            return false;
+        }
+    }
+
+    async stReportsCumulativeEnergy( deviceId, component )
+    {
+        try
+        {
+            const stValue = await this.homey.app.getDeviceCapabilityValue( deviceId, component, 'energyMeter' );
+            const energy = _.get( stValue, 'energy.value' );
+            if ( energy !== undefined && energy !== null )
+            {
+                return true;
+            }
+        }
+        catch ( err )
+        {
+            // Try the powerConsumptionReport fallback below.
+        }
+
+        try
+        {
+            const stValue = await this.homey.app.getDeviceCapabilityValue( deviceId, component, 'powerConsumptionReport' );
+            const energy = _.get( stValue, 'powerConsumption.value.energy' );
+            return ( energy !== undefined && energy !== null );
+        }
+        catch ( err )
+        {
+            this.homey.app.updateLog( `${this.getName()} does not report cumulative energy, so no kWh total is available` );
+            return false;
         }
     }
 

--- a/drivers/stDevice/device.js
+++ b/drivers/stDevice/device.js
@@ -688,7 +688,20 @@ class STDevice extends Homey.Device
 
                     if ( !value )
                     {
-						stValue = await this.homey.app.getDeviceCapabilityValue( devData.id, component, selectedCapabilityID );
+						try
+						{
+							stValue = await this.homey.app.getDeviceCapabilityValue( devData.id, component, selectedCapabilityID );
+						}
+						catch ( err )
+						{
+							// The ST device doesn't support this capability, so try the fallback before giving up
+							if ( !mapEntry.fallback )
+							{
+								throw err;
+							}
+
+							stValue = null;
+						}
 
 						if ( !stValue && mapEntry.fallback )
 						{

--- a/drivers/stDevice/driver.compose.json
+++ b/drivers/stDevice/driver.compose.json
@@ -64,6 +64,28 @@
         {
             "type": "group",
             "label": {
+                "en": "Energy",
+                "ko": "에너지"
+            },
+            "children": [
+                {
+                    "id": "energyCumulative",
+                    "type": "checkbox",
+                    "label": {
+                        "en": "Show as home power meter in the Energy tab",
+                        "ko": "Energy 탭에 전력계로 표시"
+                    },
+                    "value": false,
+                    "hint": {
+                        "en": "Treat this device as a cumulative meter that measures the whole home, so it is shown as the power meter in the Energy tab.",
+                        "ko": "이 기기를 집 전체 사용량을 측정하는 누적 미터로 취급하여 Energy 탭에 전력계로 표시합니다."
+                    }
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "label": {
                 "en": "Date",
                 "nl": "RGBW-lamp"
             },


### PR DESCRIPTION

## Problem

SmartThings devices that only report power/energy (e.g. whole-home energy monitors) were paired in Homey as a plain sensor with just a `meter_power` capability. They never appeared in Homey's Energy tab as a power meter, and live power readings (W) were missing entirely.

## Root causes

1. **Swapped capability mappings.** In the pairing table (`CapabilityMap2`), the SmartThings `energyMeter` capability (accumulated energy, kWh) was mapped to Homey's `measure_power` (instantaneous power, W), and `powerMeter` (W) was mapped to `meter_power` (kWh) — the exact opposite of the data-fetch mappings in `CapabilityMap1`.
2. **Fallback sources never ran.** `getDeviceCapabilityValue()` throws on HTTP 422/403 when a SmartThings device does not support the queried capability, and `getDeviceValues()` reacted by removing the Homey capability immediately — before the configured fallback source (`powerConsumptionReport`) ever got a chance to run. Combined with the swapped mapping, this is why devices ended up with only `meter_power`.

## Changes

- **Fix the swapped mappings**: `energyMeter` → `meter_power` (kWh) and `powerMeter` → `measure_power` (W), matching the data-fetch tables.
- **Try the fallback before removing a capability**: when the primary SmartThings capability query is rejected with 422/403 and a fallback source is defined, the fallback is queried first; the capability is only removed if no source can provide data.
- **Mark pure meter devices as cumulative**: devices that report power/energy but have no switch are now paired with `energy: { "cumulative": true }`, so Homey shows them as the home power meter in the Energy tab.
- **Per-device toggle**: a new *"Show as home power meter in the Energy tab"* checkbox (Energy group, EN/KO localized) lets users turn the cumulative-meter treatment on or off per device. Changes take effect immediately via `Device.setEnergy()`.
- **Migration for existing devices**: on init, devices with `meter_power` regain the missing `measure_power` capability when the SmartThings device actually reports `powerMeter`, and a one-time migration (guarded by a store flag) defaults the new toggle to ON for pure meter devices (sensor class, no `onoff`) and OFF for everything else.

## Testing

- Installed on a Homey Pro (self-hosted) with a SmartThings whole-home energy meter: the device now appears in the Energy tab as a cumulative power meter, with live W and accumulated kWh.
- Verified the toggle in the device's advanced settings switches the Energy-tab treatment on/off without an app restart.
- `homey app validate` passes at level `debug`.